### PR TITLE
add `templateOptions` to pass options to templater

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,28 @@ generateDocx(options, (error, buf) => {
 })
 ```
 
+## Options
+If you need to pass an [option object](https://docxtemplater.readthedocs.io/en/latest/configuration.html) to configure docxtemplater you can do using `templateOptions`.   
+For example you can configure docxtemplater to parse `\n` as a linebreak in the document
+```js
+const options = {
+  template: {
+    filePath: 'test/data/testdoc.docx',
+    data: {
+      title: 'This is the title',
+      description: 'Description is good',
+      body: 'My body is \n my temple'
+    }
+  },
+  templateOptions: {
+      linebreaks: true
+  },
+  save: {
+    filePath: 'test/data/savedfile.docx'
+  }
+}
+```
+
 ## License
 
 [MIT](LICENSE)

--- a/index.js
+++ b/index.js
@@ -24,10 +24,12 @@ const generateDocx = async options => {
 
   const template = await readFile(options.template.filePath, 'binary')
   const zip = new JSzip(template)
+  const templateOptions = options.templateOptions || {}
 
   const document = new Docxtemplater()
     .loadZip(zip)
     .setData(options.template.data)
+    .setOptions(templateOptions)
     .render()
 
   const buf = document

--- a/test/generate-docx-templateOptions.js
+++ b/test/generate-docx-templateOptions.js
@@ -1,0 +1,19 @@
+const test = require('ava')
+const generateDocx = require('../index')
+
+test('it can configure docxtemplater with an options object ', async t => {
+  const options = {
+    template: {
+      filePath: 'test/data/testdoc.docx',
+      data: {
+        title: 'hello \n world'
+      }
+    },
+    templateOptions: {
+      linebreaks: true,
+      paragraphLoop: true
+    }
+  }
+  const buf = await generateDocx(options)
+  t.true(buf instanceof Buffer)
+})


### PR DESCRIPTION
Add `templateOptions` to options to configure docxtemplater with an options object. 
e.g. you can configure docxtemplater to parse `\n` as a linebreak in the document.
```
const options = {
    template: {
      filePath: 'test/data/testdoc.docx',
      data: {
        title: 'This is the title',
        description: 'Description is good',
        body: 'My body is \n my temple'
      }
    },
    templateOptions: {
          linebreaks: true
    },
  save: {
    filePath: 'test/data/savedfile.docx'
  }
}
```
